### PR TITLE
View helper set up.

### DIFF
--- a/alliance/apps/backlog/views/check_backlogs_view.py
+++ b/alliance/apps/backlog/views/check_backlogs_view.py
@@ -6,6 +6,7 @@ from django.utils.dateparse import parse_datetime
 from ..util import retrieve_backlogs_by_status_project_and_priority
 from apps.shared.models import Backlog
 from apps.shared.views.mixins.requiresigninajax import RequireSignIn
+from core.util.views_helper import get_object_or_none
 
 
 class CheckBacklogsView(RequireSignIn, View):
@@ -33,26 +34,22 @@ class CheckBacklogsView(RequireSignIn, View):
                 #  existing into database.
                 for ui_backlog in ui_backlogs:
                     backlog_id = ui_backlog.get('id')
-                    try:
-                        backlog = Backlog.objects.get(id=backlog_id)
-                    except Backlog.DoesNotExist:
-                        # Maybe this backlog has been deleted by an
-                        #  admin user.
-                        result['outdated'] = True
-                    else:
-                        # Database datetime has greater precision than
-                        #  the one brought from ui so we add a timedelta,
-                        #  otherwise the page that executed the update
-                        #  would show the message of requested refresh.
-                        ui_last_update = parse_datetime(
-                            ui_backlog.get('lastUpdated'))
-                        db_last_update = backlog.update_dttm
+                    backlog = Backlog.objects.get_object_or_none(id=backlog_id)
 
-                        if not ui_last_update and db_last_update:
-                            result['outdated'] = True
-                        elif db_last_update:
-                            ui_last_update += datetime.timedelta(
+                    result['outdated'] = backlog == None
+                    # Database datetime has greater precision than
+                    # the one brought from ui so we add a timedelta,
+                    # otherwise the page that executed the update
+                    # would show the message of requested refresh.
+                    ui_last_update = parse_datetime(
+                            ui_backlog.get('lastUpdated'))
+                    db_last_update = backlog.update_dttm
+
+                    if not ui_last_update and db_last_update:
+                        result['outdated'] = True
+                    elif db_last_update:
+                        ui_last_update += datetime.timedelta(
                                 milliseconds=500)
-                            if db_last_update > ui_last_update:
-                                result['outdated'] = True
+                        if db_last_update > ui_last_update:
+                            result['outdated'] = True
         return JsonResponse(result)

--- a/alliance/apps/backlog/views/check_backlogs_view.py
+++ b/alliance/apps/backlog/views/check_backlogs_view.py
@@ -34,9 +34,9 @@ class CheckBacklogsView(RequireSignIn, View):
                 #  existing into database.
                 for ui_backlog in ui_backlogs:
                     backlog_id = ui_backlog.get('id')
-                    backlog = Backlog.objects.get_object_or_none(id=backlog_id)
+                    backlog = get_object_or_none(Backlog, id=backlog_id)
 
-                    result['outdated'] = backlog == None
+                    result['outdated'] = backlog is None
                     # Database datetime has greater precision than
                     # the one brought from ui so we add a timedelta,
                     # otherwise the page that executed the update

--- a/alliance/apps/backlog/views/list_backlogs_view.py
+++ b/alliance/apps/backlog/views/list_backlogs_view.py
@@ -13,8 +13,16 @@ from core.lib.shortcuts import create_json_message_object
 from ...backlog.forms import AcceptanceCriteriaFormSet,\
     EstimateForm, BacklogUpdateForm
 from apps.shared.views.mixins.requiresigninajax import RequireSignIn
+from core.lib.views_helper import get_object_or_none
 
 class BacklogView(RequireSignIn, View):
+
+    def build_estimate(estimate, team_id, backlog_id):
+        if not estimate:
+            estimate = Estimate()
+            estimate.team_id = team_id
+            estimate.backlog_id = backlog.id
+        return estimate
 
     def get(self, request):
         # Get the volunteers team
@@ -30,13 +38,9 @@ class BacklogView(RequireSignIn, View):
         for backlog in backlogs:
             read_only = backlog.status.id == queued_status_id()
 
-            try:
-                estimate = Estimate.objects.get(team_id=team_id,
-                                                backlog_id=backlog.id)
-            except Estimate.DoesNotExist:
-                estimate = Estimate()
-                estimate.team_id = team_id
-                estimate.backlog_id = backlog.id
+            estimate = build_estimate(Estimate.objects.get_object_or_none(
+                                        team_id=team_id,
+                                        backlog_id=backlog.id))
 
             # Creates the backlog form to edit data like story descr, skills,
             # notes, etc
@@ -76,14 +80,11 @@ class BacklogView(RequireSignIn, View):
         return JsonResponse(results)
 
     def update_estimate(self, request, results, team_id):
-        backlog_id = request.POST.get('estimate-backlog_id')
         from ...backlog.forms import EstimateForm
-        try:
-            estimate = Estimate.objects.get(
-                team_id=team_id, backlog_id=backlog_id)
-        except Estimate.DoesNotExist:
-            estimate = None
 
+        backlog_id = request.POST.get('estimate-backlog_id')
+        estimate = Estimate.objects.get_object_or_none(
+                team_id=team_id, backlog_id=backlog_id)
         form = EstimateForm(request.POST, prefix='estimate',
                             instance=estimate)
 
@@ -151,35 +152,31 @@ class BacklogView(RequireSignIn, View):
                     str(e), code="exception")
 
     def update_backlog_and_acc_cri(self, request, results):
-        from ...backlog.forms import BacklogUpdateForm
-        backlog_id = request.POST.get('backlog-id')
-        try:
-            backlog = Backlog.objects.get(id=backlog_id)
-        except Backlog.DoesNotExist:
-            backlog = None
-        else:
-            form = BacklogUpdateForm(request.POST,
-                                     prefix='backlog', instance=backlog)
+        from ...backlog.forms import AcceptanceCriteriaFormSet, BacklogUpdateForm
 
-            prefix = 'acceptance-criteria-%d' % backlog.id
-            from ...backlog.forms import AcceptanceCriteriaFormSet
-            formset = AcceptanceCriteriaFormSet(request.POST,
-                                                instance=backlog,
-                                                prefix=prefix)
-            if form.is_valid():
-                if formset.is_valid():
-                    backlog = form.save()
-                    backlog.refresh_from_db()
-                    formset.save()
-                    formset = AcceptanceCriteriaFormSet(
+        backlog_id = request.POST.get('backlog-id')
+        backlog = Backlog.objects.get_object_or_none(id=backlog_id)
+        form = BacklogUpdateForm(request.POST,
+                prefix='backlog', instance=backlog)
+
+        prefix = 'acceptance-criteria-%d' % backlog.id
+        formset = AcceptanceCriteriaFormSet(request.POST,
+                instance=backlog,
+                prefix=prefix)
+        if form.is_valid():
+            if formset.is_valid():
+                backlog = form.save()
+                backlog.refresh_from_db()
+                formset.save()
+                formset = AcceptanceCriteriaFormSet(
                         instance=backlog, prefix=prefix)
-                    html = render_to_string('backlog/acc_cri_par.txt',
-                                            {'form': form, 'formset': formset})
-                    results['html'] = html
-                    results['mgt_fields'] = formset.management_form.as_p()
-                    results['update_dttm'] = localtime(backlog.update_dttm)
-                    results['success'] = True
-                else:
-                    results['errors'] = formset.non_form_errors()
+                html = render_to_string('backlog/acc_cri_par.txt',
+                        {'form': form, 'formset': formset})
+                results['html'] = html
+                results['mgt_fields'] = formset.management_form.as_p()
+                results['update_dttm'] = localtime(backlog.update_dttm)
+                results['success'] = True
             else:
-                results['errors'] = form.errors.as_json()
+                results['errors'] = formset.non_form_errors()
+        else:
+            results['errors'] = form.errors.as_json()

--- a/alliance/apps/backlog/views/list_backlogs_view.py
+++ b/alliance/apps/backlog/views/list_backlogs_view.py
@@ -38,7 +38,7 @@ class BacklogView(RequireSignIn, View):
         for backlog in backlogs:
             read_only = backlog.status.id == queued_status_id()
 
-            estimate = build_estimate(Estimate.objects.get_object_or_none(
+            estimate = build_estimate(get_object_or_none(Estimate,
                                         team_id=team_id,
                                         backlog_id=backlog.id))
 
@@ -83,7 +83,7 @@ class BacklogView(RequireSignIn, View):
         from ...backlog.forms import EstimateForm
 
         backlog_id = request.POST.get('estimate-backlog_id')
-        estimate = Estimate.objects.get_object_or_none(
+        estimate = get_object_or_none(Estimate,
                 team_id=team_id, backlog_id=backlog_id)
         form = EstimateForm(request.POST, prefix='estimate',
                             instance=estimate)
@@ -155,7 +155,7 @@ class BacklogView(RequireSignIn, View):
         from ...backlog.forms import AcceptanceCriteriaFormSet, BacklogUpdateForm
 
         backlog_id = request.POST.get('backlog-id')
-        backlog = Backlog.objects.get_object_or_none(id=backlog_id)
+        backlog = get_object_or_none(Backlog, id=backlog_id)
         form = BacklogUpdateForm(request.POST,
                 prefix='backlog', instance=backlog)
 

--- a/alliance/core/lib/views_helper.py
+++ b/alliance/core/lib/views_helper.py
@@ -1,0 +1,14 @@
+from django.shortcuts import _get_queryset
+from django.core.exceptions import MultipleObjectsReturned
+from django.db.models.Model import DoesNotExist
+
+
+def get_object_or_none(klass, **kwargs):
+    """
+    This function safely returns an object without throwing exceptions for
+    DoesNotExist or MultipleObjectsReturned. It is should be used in the view.
+    """
+    try:
+        return _get_queryset(klass).get(**kwargs)
+    except (DoesNotExist, MultipleObjectsReturned):
+        return None


### PR DESCRIPTION
# Context

There should be a helper method for views to ensure that we safely handle objects that are not found by catching exceptions and returning a `None` type object.

# Cause

There is a repeated pattern in a few of the views that we have. The patten is as follows:

    try:
        instance = ModelClass.objects.filter(kwarg1=val1, kwarg2=val2, ...)
    except ModelClass.DoesNotExist:
        instance = None

# Solution

This commit addresses issue #17 . This commit adds a view helper for `get_object_or_none`. This will safely return a `None` type if an attribute does not exist on an object.