### PR TITLE
html/text typos - updated line 242 and 158

### DIFF
--- a/alliance/apps/backlog/templates/backlog/backlog_list.html
+++ b/alliance/apps/backlog/templates/backlog/backlog_list.html
@@ -155,7 +155,7 @@
                     })
                     backlog_id = $(form).find("#id_backlog-id").attr('value');
                     updateDttm(backlog_id, data.update_dttm);
-                    showMessage("Backlog successfuly updated.");
+                    showMessage("Backlog successfully updated.");
                 } else
                     showErrors(data.errors);
             });
@@ -239,6 +239,6 @@
             {% endfor %}
         </table>
     {% else %}
-        <p>There are no backlogs available.</p>
+        <p>There are no open User Stories to show for this backlog.</p>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
On line 158 corrected typo for the word successfully
On line 242 updated the text to "There are no open User Stories to show for this backlog"