### PR TITLE
issue-38 Remove hard coding of urls

### DIFF
--- a/alliance/apps/backlog/templates/backlog/backlog_list.html
+++ b/alliance/apps/backlog/templates/backlog/backlog_list.html
@@ -77,7 +77,7 @@
                         "lastUpdated": lastUpdated
                     });
             });
-            var posting = $.post("/alliance/apps/backlog/checkBacklogs", JSON.stringify(jsonData));
+            var posting = $.post("{% url 'checkBacklogsUpdate' %}", JSON.stringify(jsonData));
             posting.done(function (data) {
                 if (data.outdated) {
                     showMessage('This backlog table is outdated. Please refresh your page.');
@@ -85,7 +85,7 @@
             });
             posting.fail(function (xhr) {
                 if (xhr.status == '401') {
-                    redirectToLogin($(location).attr('pathname'));
+                    redirectToLogin("{% url 'login' %}", $(location).attr('pathname'));
                 }
             });
         }
@@ -93,7 +93,7 @@
         function updateSprint(form) {
             var data = $(form).serializeArray();
             data.push({ name: 'action-select-sprint', value: true });
-            var posting = $.post("/alliance/apps/backlog/", $.param(data));
+            var posting = $.post("{% url 'backlogs' %}", $.param(data));
             posting.done(function (data) {
                 if (data.success) {
                     newStatus = data.status;
@@ -112,7 +112,7 @@
             });
             posting.fail(function (xhr) {
                 if (xhr.status == '401') {
-                    redirectToLogin($(location).attr('pathname'));
+                    redirectToLogin("{% url 'login' %}", $(location).attr('pathname'));
                 }
             });
         }
@@ -120,7 +120,7 @@
         function updateEstimate(form) {
             var data = $(form).serializeArray();
             data.push({ name: 'action-update-estimate', value: true });
-            var posting = $.post("/alliance/apps/backlog/", $.param(data));
+            var posting = $.post("{% url 'backlogs' %}", $.param(data));
             posting.done(function (data) {
                 if (data.success) {
                     backlog_id = $("#id_estimate-backlog_id").attr('value');
@@ -131,7 +131,7 @@
             });
             posting.fail(function (xhr) {
                 if (xhr.status == '401') {
-                    redirectToLogin($(location).attr('pathname'));
+                    redirectToLogin("{% url 'login' %}", $(location).attr('pathname'));
                 }
             });
         }
@@ -139,7 +139,7 @@
         function updateBacklog(form) {
             var data = $(form).serializeArray();
             data.push({ name: 'action-save', value: true });
-            var posting = $.post("/alliance/apps/backlog/", $.param(data))
+            var posting = $.post("{% url 'backlogs' %}", $.param(data))
             posting.done( function (data) {
                 if (data.success) {
                     $(form).find('tbody').empty().append(data.html);
@@ -161,7 +161,7 @@
             });
             posting.fail(function (xhr) {
                 if (xhr.status == '401') {
-                    redirectToLogin($(location).attr('pathname'));
+                    redirectToLogin("{% url 'login' %}", $(location).attr('pathname'));
                 }
             });
         }

--- a/alliance/apps/shared/static/core/js/common.js
+++ b/alliance/apps/shared/static/core/js/common.js
@@ -14,11 +14,10 @@ function getCookie(name) {
     return cookieValue;
 }
 
-function redirectToLogin(next) {
-    url = "/accounts/login";
+function redirectToLogin(loginUrl, next) {
     if (next != null)
-        url = url + "/?next=" + next;
-    window.location.replace(url);
+        loginUrl = loginUrl + "/?next=" + next;
+    window.location.replace(loginUrl);
 }
 
 function showMessage(message) {

--- a/alliance/apps/shared/templates/core/choose_team.txt
+++ b/alliance/apps/shared/templates/core/choose_team.txt
@@ -1,5 +1,5 @@
 <div id="dialog-form" title="Select a Team">
-    <form id="choose-team-form" action='/alliance/' method="post">{% csrf_token %}
+    <form id="choose-team-form" action="{% url 'chooseTeam' %}" method="post">{% csrf_token %}
         <div>
             {{ form.team }}
             <!-- Allow form submission with keyboard without duplicating the dialog button -->

--- a/alliance/apps/shared/templates/core/index.html
+++ b/alliance/apps/shared/templates/core/index.html
@@ -34,7 +34,7 @@
 <a href="{% url 'backlogs' %}">{% trans "List Backlog for current user" %}</a>
 {% if teams %}
 <div id="dialog-form" title="Select a Team">
-    <form action='/alliance/' method="post">{% csrf_token %}
+    <form action='{% url 'chooseTeam' %}' method="post">{% csrf_token %}
         <div>
             {{ form.team }}
             <!-- Allow form submission with keyboard without duplicating the dialog button -->

--- a/alliance/apps/shared/templates/shared/base.html
+++ b/alliance/apps/shared/templates/shared/base.html
@@ -13,11 +13,11 @@
     <script type="text/javascript" language="javascript">
     $(document).ready(function(){
         $("#choose-team").click(function (e) {
-            var getting = $.get("/alliance/core/chooseTeam");
+            var getting = $.get("{% url 'chooseTeam' %}");
             getting.done(function (data) {
                 if (data.success) {
                     $("#dialog-form").remove();
-                    $("body").append(data.html)
+                    $("body").append(data.html);
                     $("#dialog-form").dialog({modal: true});
                     var dialog, form, team = $("#team");
                     dialog = $("#dialog-form").dialog({
@@ -38,7 +38,7 @@
                                 });
                                 posting.fail(function (xhr) {
                                     if (xhr.status == '401') {
-                                        redirectToLogin($(location).attr('pathname'));
+                                        redirectToLogin("{% url 'login' %}", $(location).attr('pathname'));
                                     }
                                 });
                             },
@@ -59,7 +59,7 @@
             });
             getting.fail(function (xhr) {
                 if (xhr.status == '401') {
-                    redirectToLogin($(location).attr('pathname'));
+                    redirectToLogin("{% url 'login' %}", $(location).attr('pathname'));
                 }
             });
             return false;
@@ -77,7 +77,7 @@
             {% block topmenu %}
                 <a href="{% url 'index' %}">{% trans "Home" %}</a> |
                 {% if user.is_authenticated %}
-                    <a href="{% url 'logout' %}?next=/alliance/">{% trans "Log out" %}</a> |
+                    <a href="{% url 'logout' %}?next={% url 'index' %}">{% trans "Log out" %}</a> |
                     <a id="choose-team" href="javascript:void(0)">{% trans "Change Team" %}</a> |
                     {% trans "Logged in as" %}: {{ user.username }}
                 {% else %}


### PR DESCRIPTION
For issue 38, we're replacing all hard coded urls with reverse lookups.

Currently, nothing works because the master branch gives me this error when running ./manage.py:
```
ImportError: No module named alliance.config.settings.base
```

I think we should keep a goal that it is always possible to checkout master and run the local server. I know we can't keep out every bug, but we should be able to try "./manage.py runserver" and see that it works before we merge to master.