### PR TITLE
Removing '/' that was causing 404 error when redirect to the login page occurs

### DIFF
--- a/alliance/apps/shared/static/core/js/common.js
+++ b/alliance/apps/shared/static/core/js/common.js
@@ -16,7 +16,7 @@ function getCookie(name) {
 
 function redirectToLogin(loginUrl, next) {
     if (next != null)
-        loginUrl = loginUrl + "/?next=" + next;
+        loginUrl = loginUrl + "?next=" + next;
     window.location.replace(loginUrl);
 }
 


### PR DESCRIPTION
This may be related to the issue #71 