### PR TITLE
logs-WriteInHerokuConsole

### DIFF
--- a/alliance/config/settings.py
+++ b/alliance/config/settings.py
@@ -95,7 +95,12 @@ LOGGING = {
         },
     },
     'handlers': {
-        'file': {
+        'console':{
+			'level': 'DEBUG',
+			'class': 'logging.StreamHandler',
+			'formatter': 'verbose'
+		},
+		'file': {
             'level': 'DEBUG',
             'class': 'logging.handlers.TimedRotatingFileHandler',
             'filename': os.path.join(LOG_FOLDER, 'alliance.log'),
@@ -106,12 +111,12 @@ LOGGING = {
     },
     'loggers': {
         'django': {
-            'handlers':['file'],
+            'handlers':['console', 'file'],
             'propagate': True,
             'level':'DEBUG',
         },
         'alliance': {
-            'handlers': ['file'],
+            'handlers': ['console', 'file'],
             'level': 'DEBUG',
         },
     }


### PR DESCRIPTION
This file changes are to address logs config settings where, "Logs are not writing to a file in Heroku as designed in Django alliance app". However, currently fixed settings to write logs in Heroku console. Need to research more and work with Heroku team if required to understand the changes at Heroku end in next/future sprint to address the actual issue (logs are not written to a file in Heroku).